### PR TITLE
Cleanup testing scripts 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker build
+name: Test Docker
 on:
   pull_request:
     paths:

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -13,17 +13,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install latest uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
 
-      - name: Setup the necessary deps
+      - name: Install dependencies
+        run: uv sync --group docs --all-extras
+
+      - name: Install lldb
         run: |
-          # https://github.com/pwndbg/pwndbg/blob/dev/DEVELOPING.md#install-from-source-lldb
+          # https://pwndbg.re/pwndbg/dev/contributing/setup-pwndbg-dev/#running-with-lldb
           sudo apt update
           sudo apt install -y gdb lldb-19 liblldb-19-dev
           echo "/usr/lib/llvm-19/bin/" >> $GITHUB_PATH
           echo "/usr/lib/llvm-19/bin/lldb-server" >> $GITHUB_PATH
-          uv sync --extra lldb --group docs
 
       - name: Verify docs are up to date with source
         run: |
@@ -48,8 +52,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install latest uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group docs
 
       - name: Update docs/index.md with README.md
         run: ./scripts/generate-readme.sh

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -19,8 +19,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install latest uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group docs
 
       - name: Update docs/index.md with README.md
         run: ./scripts/generate-readme.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,18 +17,22 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
+
     - name: Cache for pip
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-cache-pip
 
+    - name: Install latest uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "latest"
+
     - name: Install dependencies
       run: |
-        sudo apt install -y shfmt python3 python3-venv
-        python3 -m venv -- .venv
-        ./.venv/bin/pip install uv
-        ./.venv/bin/uv sync --group dev --extra gdb --extra lldb
+        sudo apt install -y shfmt curl
+        uv sync --group lint --group dev
 
     - name: Run linters
       run: |
@@ -46,7 +50,7 @@ jobs:
         level: error
         # Change the current directory to run mypy command.
         # mypy command reads setup.cfg or other settings file in this path.
-        execute_command: ./.venv/bin/uv run --only-group lint mypy
+        execute_command: uv run --group lint --group dev mypy
         install_types: false
         target: pwndbg
         filter_mode: nofilter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,26 +54,27 @@ jobs:
     - name: Run cross-arch tests
       if: matrix.type == 'qemu-user-tests'
       run: |
-        ./qemu-tests.sh --nix --cov
+        ./crossarch-tests.sh --nix --cov
 
     - name: Set up cache for QEMU images
       if: matrix.type == 'qemu-system-tests'
       id: qemu-cache
       uses: actions/cache@v3
       with:
-        path: ./tests/qemu-tests/images
+        path: ./tests/qemu-tests/kimages
         key: ${{ matrix.os }}-cache-qemu-images
 
     - name: Download QEMU images
       if: matrix.type == 'qemu-system-tests'
       run: |
-        ./tests/qemu-tests/download_images.sh
+        # Would happen in the next step as well, but this way
+        # it looks nicer in the CI.
+        ./tests/qemu-tests/download-kernel-images.sh
 
     - name: Run kernel tests
       if: matrix.type == 'qemu-system-tests'
-      working-directory: ./tests/qemu-tests
       run: |
-        ./tests.sh --nix --cov
+        ./kernel-tests.sh --nix --cov
 
   tests:
     strategy:
@@ -142,7 +143,7 @@ jobs:
 
     - name: Run cross-architecture tests
       run: |
-        ./qemu-tests.sh --cov
+        ./crossarch-tests.sh --cov
 
     - name: Process coverage data
       run: |
@@ -174,19 +175,18 @@ jobs:
       id: qemu-cache
       uses: actions/cache@v3
       with:
-        path: ./tests/qemu-tests/images
+        path: ./tests/qemu-tests/kimages
         key: ${{ matrix.os }}-cache-qemu-images
 
     - name: Download images
       run: |
-        ./tests/qemu-tests/download_images.sh
+        ./tests/qemu-tests/download-kernel-images.sh
 
     # We set `kernel.yama.ptrace_scope=0` for `gdb-pt-dump`
     - name: Run kernel tests
-      working-directory: ./tests/qemu-tests
       run: |
         sudo sysctl -w kernel.yama.ptrace_scope=0
-        ./tests.sh --cov
+        ./kernel-tests.sh --cov
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Tests
 on:
   push:
     branches:
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 40
     env:
       TMPDIR: /tmp
+      PWNDBG_VENV_PATH: PWNDBG_PLEASE_SKIP_VENV
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # @v3
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # @v30
@@ -89,7 +90,7 @@ jobs:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-cache-pip
 
-    - name: Install dependencies
+    - name: Setup pwndbg
       run: |
         ./setup.sh
         ./setup-dev.sh
@@ -101,12 +102,11 @@ jobs:
         echo 'Installed py:'
         ./.venv/bin/python -V
         echo 'Installed packages:'
-        ./.venv/bin/python -m pip freeze
+        ./.venv/bin/pip freeze
 
     # We set `kernel.yama.ptrace_scope=0` for `attachp` command tests
     - name: Run tests
       run: |
-        source .venv/bin/activate
         mkdir .cov
         sudo sysctl -w kernel.yama.ptrace_scope=0
         ./tests.sh --cov
@@ -115,8 +115,8 @@ jobs:
     - name: Process coverage data
       if: matrix.os == 'ubuntu-22.04'
       run: |
-        ./.venv/bin/coverage combine
-        ./.venv/bin/coverage xml
+        ./.venv/bin/uv run --group tests coverage combine
+        ./.venv/bin/uv run --group tests coverage xml
 
     - name: "Upload coverage to Codecov"
       if: matrix.os == 'ubuntu-22.04'
@@ -134,7 +134,7 @@ jobs:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-cache-pip
 
-    - name: Install dependencies
+    - name: Setup pwndbg
       run: |
         ./setup.sh
         ./setup-dev.sh
@@ -146,8 +146,8 @@ jobs:
 
     - name: Process coverage data
       run: |
-        ./.venv/bin/coverage combine
-        ./.venv/bin/coverage xml
+        ./.venv/bin/uv run --group tests coverage combine
+        ./.venv/bin/uv run --group tests coverage xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
@@ -164,7 +164,7 @@ jobs:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-cache-pip
 
-    - name: Install dependencies
+    - name: Setup pwndbg
       run: |
         ./setup.sh
         ./setup-dev.sh
@@ -190,8 +190,8 @@ jobs:
 
     - name: Process coverage data
       run: |
-        ./.venv/bin/coverage combine
-        ./.venv/bin/coverage xml
+        ./.venv/bin/uv run --group tests coverage combine
+        ./.venv/bin/uv run --group tests coverage xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ tests/**/binaries/div_zero_binary/binary
 !tests/**/binaries/*.go
 
 # QEMU test images
-tests/qemu-tests/images
+tests/qemu-tests/kimages
 
 # VS Code files
 .vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     apt-get update && \
     apt-get install -y vim
 
+# setup.sh needs scripts/common.sh
+RUN mkdir scripts
+ADD ./scripts/common.sh /pwndbg/scripts/
+
 ADD ./setup.sh /pwndbg/
 ADD ./uv.lock /pwndbg/
 ADD ./pyproject.toml /pwndbg/

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -27,6 +27,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     pacman -S --noconfirm vim && \
     pacman -Scc --noconfirm
 
+# setup.sh needs scripts/common.sh
+RUN mkdir scripts
+ADD ./scripts/common.sh /pwndbg/scripts/
+
 ADD ./setup.sh /pwndbg/
 ADD ./uv.lock /pwndbg/
 ADD ./pyproject.toml /pwndbg/

--- a/Dockerfile.lldb
+++ b/Dockerfile.lldb
@@ -29,6 +29,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     apt-get update && \
     apt-get install -y vim
 
+# setup.sh needs scripts/common.sh
+RUN mkdir scripts
+ADD ./scripts/common.sh /pwndbg/scripts/
+
 ADD ./setup.sh /pwndbg/
 ADD ./uv.lock /pwndbg/
 ADD ./pyproject.toml /pwndbg/
@@ -64,4 +68,3 @@ RUN if [ ! -f ~/.lldbinit ]; then echo "command script import /pwndbg/lldbinit.p
     if id -u ${LOW_PRIVILEGE_USER} > /dev/null 2>&1; then \
         su ${LOW_PRIVILEGE_USER} -c 'if [ ! -f ~/.lldbinit ]; then echo "command script import /pwndbg/lldbinit.py" >> ~/.lldbinit; fi'; \
     fi
-

--- a/crossarch-tests.sh
+++ b/crossarch-tests.sh
@@ -2,6 +2,9 @@
 
 source "$(dirname "$0")/scripts/common.sh"
 
-(cd tests && $UV_RUN_TEST python3 tests.py -t cross-arch $@)
+cd "${PWNDBG_ABS_PATH}/tests"
+
+$UV_RUN_TEST python3 tests.py -t cross-arch $@
+
 exit_code=$?
 exit $exit_code

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -34,7 +34,9 @@ To run the tests in the same environment as the testing CI, you can use the foll
 # General (x86_64) test suite
 docker compose run --rm --build ubuntu24.04-mount ./tests.sh
 # Cross-architecture tests
-docker compose run --rm --build ubuntu24.04-mount ./qemu-tests.sh
+docker compose run --rm --build ubuntu24.04-mount ./crossarch-tests.sh
+# Kernel tests (x86_64 and aarch64)
+docker compose run --rm --build ubuntu24.04-mount ./kernel-tests.sh
 # Unit tests
 docker compose run --rm --build ubuntu24.04-mount ./unit-tests.sh
 ```
@@ -42,11 +44,9 @@ This comes in handy particularly for cross-architecture tests because the docker
 
 Remove the `-mount` if you want the tests to run from a clean slate (no files are mounted, meaning all binaries are recompiled each time).
 
-If you wish to focus on some failing tests, you can filter the tests to run by providing an argument to the script, such as `<docker..> ./tests.sh heap`, which will only run tests that contain "heap" in the name. See `./tests.sh --help` for more information and other options. You can also do this with the cross-arch tests.
+If you wish to focus on some failing tests, you can filter the tests to run by providing an argument to the script, such as `<docker..> ./tests.sh heap`, which will only run tests that contain "heap" in the name. See `./tests.sh --help` for more information and other options. You can also do this with the cross-arch and kernel tests.
 
 If you want to, you may also [run the tests with nix](#running-tests-with-nix) or [run them bare](#running-without-docker).
-
-TODO: Create a script for running kernel tests instead of running them with `./tests/qemu-tests/tests.sh`.
 
 #### Running tests with nix
 You will need to build a nix-compatible `gdbinit.py` file, which you can do with
@@ -65,22 +65,11 @@ The commands are analogous to the docker commands.
 # General (x86_64) test suite
 ./tests.sh
 # Cross-architecture tests
-./qemu-tests.sh
+./crossarch-tests.sh
+# Kernel tests (x86_64 and aarch64)
+./kernel-tests.sh
 # Unit tests
 ./unit-tests.sh
-```
-
-To run the kernel tests you will need to install the appropriate qemu-system packages for your distribution. Then download the kernel images with
-```{.bash .copy}
-./tests/qemu-tests/download_images.sh
-```
-set ptrace_scope to zero with
-```{.bash .copy}
-echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-```
-and run the kernel tests with
-```{.bash .copy}
-cd ./tests/qemu-tests/ && ./tests.sh
 ```
 
 ## Updating Documentation

--- a/docs/misc/env-vars.md
+++ b/docs/misc/env-vars.md
@@ -6,6 +6,8 @@ Pwndbg relies on several environment variables to customize its behavior. Below 
 - `EDITOR`, `VISUAL`: Used by the `cymbol` command to open an editor.
 - `HOME`, `XDG_CACHE_HOME`: Used by `lib.tempfile` to determine temporary file locations.
 - `PWNDBG_VENV_PATH`: Specifies the virtual environment path for Pwndbg.
+    - Set to `PWNDBG_PLEASE_SKIP_VENV` if you don't want Pwndbg to use a python virtual environment. You can also get this behaviour by creating a file named `.skip-venv` in the project root.
+      This effectively disables the use of `uv` in the project.
 - `PWNDBG_DISABLE_COLORS`: Disables colored output in Pwndbg.
 - `PWNDBG_LOGLEVEL`: Initial log level to use for log messages.
 - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`: Used by the `ai` command for accessing respective AI APIs.

--- a/gdbinit.py
+++ b/gdbinit.py
@@ -44,9 +44,11 @@ def hash_file(file_path: str | Path) -> str:
 def run_uv_install(
     binary_path: os.PathLike[str], src_root: Path, dev: bool = False
 ) -> Tuple[str, str, int]:
-    command: List[str] = [str(binary_path), "sync", "--extra", "gdb"]
+    # We don't want to quietly uninstall dependencies by just specifying
+    # `--extra gdb` so we will be conservative and pull all extras in.
+    command: List[str] = [str(binary_path), "sync", "--all-extras"]
     if dev:
-        command.extend(("--all-groups",))
+        command.append("--all-groups")
     logging.debug(f"Updating deps with command: {' '.join(command)}")
     result = subprocess.run(command, capture_output=True, text=True, cwd=src_root)
     return result.stdout.strip(), result.stderr.strip(), result.returncode

--- a/kernel-tests.sh
+++ b/kernel-tests.sh
@@ -4,6 +4,13 @@ source "$(dirname "$0")/scripts/common.sh"
 
 cd "${PWNDBG_ABS_PATH}/tests/qemu-tests"
 
+# Check if we have correct ptrace_scope
+ptrace_scope=$(cat /proc/sys/kernel/yama/ptrace_scope)
+if [[ $ptrace_scope -ne 0 && $(id -u) -ne 0 ]]; then
+    echo "Setting ptrace_scope to zero..."
+    echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+fi
+
 # Check if we need to download kernel images
 VMLINUX_LIST=($(basename -a "${TESTING_KERNEL_IMAGES_DIR}"/vmlinux*))
 

--- a/kernel-tests.sh
+++ b/kernel-tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/scripts/common.sh"
+
+cd "${PWNDBG_ABS_PATH}/tests/qemu-tests"
+
+# Check if we need to download kernel images
+VMLINUX_LIST=($(basename -a "${TESTING_KERNEL_IMAGES_DIR}"/vmlinux*))
+
+if [ ! -d "$TESTING_KERNEL_IMAGES_DIR" ] || [ "$VMLINUX_LIST" = "vmlinux*" ]; then
+    echo "No kernel images found. Downloading to ${TESTING_KERNEL_IMAGES_DIR}..."
+    echo "(This may take some time.)"
+    echo "(You can always run the download yourself with ./tests/qemu-tests/download-kernel-images.sh .)"
+    echo ""
+    ./download-kernel-images.sh
+    echo "Download finished."
+fi
+
+echo "Running tests..."
+./system-tests.sh
+
+exit_code=$?
+exit $exit_code

--- a/kernel-tests.sh
+++ b/kernel-tests.sh
@@ -17,7 +17,7 @@ if [ ! -d "$TESTING_KERNEL_IMAGES_DIR" ] || [ "$VMLINUX_LIST" = "vmlinux*" ]; th
 fi
 
 echo "Running tests..."
-./system-tests.sh
+./system-tests.sh $@
 
 exit_code=$?
 exit $exit_code

--- a/lint.sh
+++ b/lint.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+source "$(dirname "$0")/scripts/common.sh"
+
 help_and_exit() {
     echo "Usage: ./lint.sh [-f|--fix]"
     echo "  -f,  --fix         fix issues if possible"
@@ -26,19 +28,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Use Python virtual env for all programs used here
-if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
-    PWNDBG_VENV_PATH="./.venv"
-fi
-
-if [[ "${PWNDBG_VENV_PATH}" != "PWNDBG_PLEASE_SKIP_VENV" ]]; then
-    source "${PWNDBG_VENV_PATH}/bin/activate"
-fi
-
 set -o xtrace
 
 LINT_FILES="pwndbg tests *.py scripts"
-LINT_CMD="uv run --only-group lint"
 
 call_shfmt() {
     local FLAGS=$1
@@ -46,20 +38,21 @@ call_shfmt() {
         local SHFMT_FILES=$(find . -name "*.sh" -not -path "./.venv/*")
         # Indents are four spaces, binary ops can start a line, indent switch cases,
         # and allow spaces following a redirect
-        shfmt ${FLAGS} -i 4 -bn -ci -sr -d ${SHFMT_FILES}
+        $UV_RUN_LINT shfmt ${FLAGS} -i 4 -bn -ci -sr -d ${SHFMT_FILES}
     else
-        echo "shfmt not installed, skipping"
+        echo "shfmt not installed, please install it"
+        exit 2
     fi
 }
 
 if [[ $FIX == 1 ]]; then
-    $LINT_CMD isort ${LINT_FILES}
-    $LINT_CMD ruff format ${LINT_FILES}
-    $LINT_CMD ruff check --fix --output-format=full ${LINT_FILES}
+    $UV_RUN_LINT isort ${LINT_FILES}
+    $UV_RUN_LINT ruff format ${LINT_FILES}
+    $UV_RUN_LINT ruff check --fix --output-format=full ${LINT_FILES}
     call_shfmt -w
 else
-    $LINT_CMD isort --check-only --diff ${LINT_FILES}
-    $LINT_CMD ruff format --check --diff ${LINT_FILES}
+    $UV_RUN_LINT isort --check-only --diff ${LINT_FILES}
+    $UV_RUN_LINT ruff format --check --diff ${LINT_FILES}
     call_shfmt
 
     if [[ -z "$GITHUB_ACTIONS" ]]; then
@@ -68,13 +61,13 @@ else
         RUFF_OUTPUT_FORMAT=github
     fi
 
-    $LINT_CMD ruff check --output-format="${RUFF_OUTPUT_FORMAT}" ${LINT_FILES}
+    $UV_RUN_LINT ruff check --output-format="${RUFF_OUTPUT_FORMAT}" ${LINT_FILES}
 fi
 
 # Checking minimum python version
-$LINT_CMD vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
+$UV_RUN_LINT vermin -vvv --no-tips -t=3.10- --eval-annotations --violations ${LINT_FILES}
 
 # mypy is run in a separate step on GitHub Actions
 if [[ -z "$GITHUB_ACTIONS" ]]; then
-    $LINT_CMD mypy pwndbg gdbinit.py lldbinit.py pwndbg-lldb.py
+    $UV_RUN_LINT mypy pwndbg gdbinit.py lldbinit.py pwndbg-lldb.py
 fi

--- a/lldbinit.py
+++ b/lldbinit.py
@@ -30,9 +30,11 @@ def hash_file(file_path: str | Path) -> str:
 def run_uv_install(
     binary_path: os.PathLike[str], src_root: Path, dev: bool = False
 ) -> Tuple[str, str, int]:
-    command: List[str] = [str(binary_path), "sync", "--extra", "lldb"]
+    # We don't want to quietly uninstall dependencies by just specifying
+    # `--extra lldb` so we will be conservative and pull all extras in.
+    command: List[str] = [str(binary_path), "sync", "--all-extras"]
     if dev:
-        command.extend(("--all-groups",))
+        command.append("--all-groups")
     result = subprocess.run(command, capture_output=True, text=True, cwd=src_root)
     return result.stdout.strip(), result.stderr.strip(), result.returncode
 

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -94,6 +94,7 @@ in
       ];
     shellHook = ''
       export PWNDBG_NO_AUTOUPDATE=1
+      export PWNDBG_NO_UV=1
       export PWNDBG_VENV_PATH="${pyEnv}"
       export ZIGPATH="${pkgs.lib.getBin pkgs.zig_0_13}/bin/"
       export REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -133,6 +133,7 @@ let
     # paramiko is only used in pwntools for pwnlib.tubes.ssh
     paramiko = dummy;
     pip = dummy;
+    uv = dummy;
 
     psutil = pkgs.callPackage (
       {

--- a/profiling/benchmark.sh
+++ b/profiling/benchmark.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
+
+source "$(dirname "$0")/../scripts/common.sh"
+
 # Benchmark context command
 make test > /dev/null
 git log --abbrev-commit --pretty=oneline HEAD^..HEAD
-gdb ./test \
+
+$UV_RUN gdb ./test \
     -ex "source ../gdbinit.py" \
     -ex "b main" -ex "r" \
     -ex "python import timeit; print('      1ST RUN:', timeit.repeat('pwndbg.commands.context.context()', repeat=1, number=1, globals=globals())[0])" \

--- a/profiling/benchmark_cache/bench.sh
+++ b/profiling/benchmark_cache/bench.sh
@@ -1,31 +1,37 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 # Benchmarks current and old version of pwndbg (provided as git commit)
 # Usage: bench.sh <old-commit>
 rm *.prof *.stats
 
 set -e
 
+source "$(dirname "$0")/../../scripts/common.sh"
+
+$GDB="${UV_RUN} gdb --batch --ex 'entry'"
+$PYTHON="${UV_RUN} python3"
+
 # Current code, benchmark 1
-gdb --batch --ex 'entry' --ex 'source gdbscript1.py' --args $(which python3) -c 'import sys; sys.exit(0)'
+$GDB --ex 'source gdbscript1.py' --args $(which python3) -c 'import sys; sys.exit(0)'
 mv profile.prof curr1.prof
-python3 ../print_stats.py curr1.prof > curr1.stats
+$PYTHON ../print_stats.py curr1.prof > curr1.stats
 
 # Current code, benchmark 2
-gdb --batch --ex 'entry' --ex 'source gdbscript2.py' --args $(which python3) -c 'import sys; sys.exit(0)'
+$GDB --ex 'source gdbscript2.py' --args $(which python3) -c 'import sys; sys.exit(0)'
 mv profile.prof curr2.prof
-python3 ../print_stats.py curr2.prof > curr2.stats
+$PYTHON ../print_stats.py curr2.prof > curr2.stats
 
 # Switch to old version
 git checkout $1
 
 # Old code, benchmark 1
-gdb --batch --ex 'entry' --ex 'source gdbscript1.py' --args $(which python3) -c 'import sys; sys.exit(0)'
+$GDB --ex 'source gdbscript1.py' --args $(which python3) -c 'import sys; sys.exit(0)'
 mv profile.prof old1.prof
-python3 ../print_stats.py old1.prof > old1.stats
+$PYTHON ../print_stats.py old1.prof > old1.stats
 
 # Old code, benchmark 2
-gdb --batch --ex 'entry' --ex 'source gdbscript2.py' --args $(which python3) -c 'import sys; sys.exit(0)'
+$GDB --ex 'source gdbscript2.py' --args $(which python3) -c 'import sys; sys.exit(0)'
 mv profile.prof old2.prof
-python3 ../print_stats.py old2.prof > old2.stats
+$PYTHON ../print_stats.py old2.prof > old2.stats
 
 git checkout -

--- a/profiling/benchmark_vis_heap_chunks/bench.sh
+++ b/profiling/benchmark_vis_heap_chunks/bench.sh
@@ -1,2 +1,5 @@
-#!/bin/sh
-gdb --batch --ex 'break exit' --ex 'run' --ex 'source gdbscript.py' --args $(which python3) -c 'import sys; sys.exit(0)'
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../../scripts/common.sh"
+
+$UV_RUN gdb --batch --ex 'break exit' --ex 'run' --ex 'source gdbscript.py' --args $(which python3) -c 'import sys; sys.exit(0)'

--- a/profiling/profile.sh
+++ b/profiling/profile.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "$(dirname "$0")/../scripts/common.sh"
+
 if ! (($#)); then
     cat <<- _EOF_
 		$0: [profile-script]
@@ -15,7 +17,7 @@ basedir=$(dirname "$0")
 # Quick and dirty script to profile pwndbg using cProfile.
 make -C "${basedir}" test > /dev/null
 
-gdb "${basedir}/test" \
+$UV_RUN gdb "${basedir}/test" \
     -ex "source ${basedir}/../gdbinit.py" \
     -ex "b main" \
     -ex "r" \
@@ -26,14 +28,14 @@ profile.warmup();
 cProfile.run('profile.run()', '${basedir}/stats')" \
     -ex "quit"
 
-python3 -c "
+$UV_RUN python3 -c "
 import pstats
 p = pstats.Stats('${basedir}/stats')
 p.strip_dirs().sort_stats('tottime').print_stats(20)
 "
 
 if command -v pyprof2calltree &> /dev/null && command -v kcachegrind &> /dev/null; then
-    pyprof2calltree -k -i "${basedir}/stats"
+    $UV_RUN pyprof2calltree -k -i "${basedir}/stats"
 fi
 
 # vim: ts=4 sw=4 noet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "pyelftools>=0.29,<0.30",
     "pygments>=2.18.0,<3",
     "psutil>=6.1.1,<7",
+    # We install uv to the venv
+    "uv>=0.7.6",
     # Optional? only for 'ipi' command
     "ipython>=8.27.0,<9",
     # Optional? only for 'ropgadget' command

--- a/qemu-tests.sh
+++ b/qemu-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
-(cd tests && python3 tests.py -t cross-arch $@)
+source "$(dirname "$0")/scripts/common.sh"
+
+(cd tests && $UV_RUN_TEST python3 tests.py -t cross-arch $@)
 exit_code=$?
 exit $exit_code

--- a/scripts/_docs/build-all-docs.sh
+++ b/scripts/_docs/build-all-docs.sh
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../common.sh"
 
 # This may perform verification instead of building
 # depending on PWNDBG_DOCGEN_VERIFY.
-uv run --group docs python ./scripts/_docs/build_command_docs.py || exit 1
-uv run --group docs python ./scripts/_docs/build_configuration_docs.py || exit 2
-uv run --group docs python ./scripts/_docs/build_function_docs.py || exit 3
+$UV_RUN_DOCS python ./scripts/_docs/build_command_docs.py || exit 1
+$UV_RUN_DOCS python ./scripts/_docs/build_configuration_docs.py || exit 2
+$UV_RUN_DOCS python ./scripts/_docs/build_function_docs.py || exit 3

--- a/scripts/_docs/extract-all-docs.sh
+++ b/scripts/_docs/extract-all-docs.sh
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../common.sh"
 
 # Extract from sources all the information necessary to build
 # the documentation. Do this from each debugger.
 
 export PWNDBG_DOCGEN_DBGNAME="gdb"
-uv run --group docs gdb --batch -nx -ix ./gdbinit.py \
+$UV_RUN_DOCS gdb --batch -nx -ix ./gdbinit.py \
     -iex "set exception-verbose on" \
     -ix ./scripts/_docs/extract_command_docs.py \
     -ix ./scripts/_docs/extract_configuration_docs.py \
@@ -13,7 +15,7 @@ uv run --group docs gdb --batch -nx -ix ./gdbinit.py \
 
 export PWNDBG_DOCGEN_DBGNAME="lldb"
 {
-    uv run --group docs --extra lldb python pwndbg-lldb.py << EOF
+    $UV_RUN_DOCS python pwndbg-lldb.py << EOF
 set show-tips off
 command script import ./scripts/_docs/extract_command_docs.py
 command script import ./scripts/_docs/extract_configuration_docs.py

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,6 +4,8 @@ _COMMON_ABS_DIR=$(realpath "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")
 # dirname of a directory gives the parent directory.
 PWNDBG_ABS_PATH=$(dirname $_COMMON_ABS_DIR)
 
+TESTING_KERNEL_IMAGES_DIR="${PWNDBG_ABS_PATH}/tests/qemu-tests/kimages"
+
 if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
     PWNDBG_VENV_PATH="${PWNDBG_ABS_PATH}/.venv"
 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+_COMMON_ABS_DIR=$(realpath "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")
+# dirname of a directory gives the parent directory.
+PWNDBG_ABS_PATH=$(dirname $_COMMON_ABS_DIR)
+
+if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
+    PWNDBG_VENV_PATH="${PWNDBG_ABS_PATH}/.venv"
+fi
+
+if [[ "$PWNDBG_VENV_PATH" == "PWNDBG_PLEASE_SKIP_VENV" || -f "${PWNDBG_ABS_PATH}/.skip-venv" || "$PWNDBG_NO_UV" == "1" ]]; then
+    # We are using the dependencies as installed on the system
+    # so we shouldn't use uv (and can't, since it's not installed).
+    UV=""
+    UV_RUN=""
+    UV_RUN_TEST=""
+    UV_RUN_LINT=""
+    UV_RUN_DOCS=""
+else
+    # We are going to use uv.
+    UV="${PWNDBG_VENV_PATH}/bin/uv"
+    UV_RUN="${UV} run"
+    UV_RUN_TEST="${UV_RUN} --group dev --group tests --all-extras"
+    UV_RUN_LINT="${UV_RUN} --group dev --group lint"
+    UV_RUN_DOCS="${UV_RUN} --group docs --extra gdb --extra lldb"
+fi

--- a/scripts/docs-live.sh
+++ b/scripts/docs-live.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-uv run --group docs mkdocs serve -a 0.0.0.0:8000
+
+source "$(dirname "$0")/common.sh"
+
+$UV_RUN_DOCS mkdocs serve -a 0.0.0.0:8000

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Extract the documentation.
 echo "Extracting docs.."

--- a/scripts/generate-readme.sh
+++ b/scripts/generate-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 rm ./docs/index.md
 echo "---

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source "$(dirname "$0")/common.sh"
+
 OLD_VER="$1"
 NEW_VER="$2"
 
@@ -30,4 +32,4 @@ portable_sed_replace $OLD_VER $NEW_VER ./docs/setup.md
 portable_sed_replace $OLD_VER $NEW_VER ./docs/install.sh
 
 # Rebuild uv.lock file after version change
-uv lock
+$UV lock

--- a/scripts/verify-docs.sh
+++ b/scripts/verify-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Extract the documentation.
 echo "Extracting docs.."

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -144,7 +144,8 @@ install_apt() {
         parallel \
         qemu-system-x86 \
         qemu-system-arm \
-        qemu-user
+        qemu-user \
+        iproute2
 
     # Some tests require i386 libc/ld, eg: test_smallbins_sizes_32bit_big
     if uname -m | grep -q x86_64; then
@@ -197,6 +198,8 @@ EOF
         base-devel \
         gdb \
         parallel
+
+    # FIXME: add the necessary deps for testing
 
     command -v go &> /dev/null || sudo pacman -S --noconfirm go
 

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+source "$(dirname "$0")/scripts/common.sh"
+
 echo "# --------------------------------------"
 echo "# Install testing tools."
 echo "# Only works with Ubuntu / APT or Arch / Pacman."
@@ -8,7 +10,7 @@ echo "# --------------------------------------"
 
 help_and_exit() {
     echo "Usage: ./setup-dev.sh [--install-only]"
-    echo "  --install-only              install only distro dependencies without installing python-venv"
+    echo "  --install-only              install only distro dependencies without syncing the python venv"
     exit 1
 }
 
@@ -287,13 +289,7 @@ install_jemalloc() {
 }
 
 configure_venv() {
-    if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
-        PWNDBG_VENV_PATH="./.venv"
-    fi
-    echo "Using virtualenv from path: ${PWNDBG_VENV_PATH}"
-
-    source "${PWNDBG_VENV_PATH}/bin/activate"
-    uv sync --all-groups --all-extras
+    $UV sync --all-groups --all-extras
 
     # Create a developer marker file
     DEV_MARKER_PATH="${PWNDBG_VENV_PATH}/dev.marker"

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+source "$(dirname "$0")/scripts/common.sh"
+
 # If we are a root in a container and `sudo` doesn't exist
 # lets overwrite it with a function that just executes things passed to sudo
 # (yeah it won't work for sudo executed with flags)
@@ -206,20 +208,20 @@ if [[ -z "$is_supported" ]]; then
     exit 4
 fi
 
-# Create the Python virtual environment and install dependencies using uv
-if [[ -z "${PWNDBG_VENV_PATH}" ]]; then
-    PWNDBG_VENV_PATH="./.venv"
-fi
+# Create the python virtual environment
+# We don't care about PWNDBG_PLEASE_SKIP_VENV here.
 echo "Creating virtualenv in path: ${PWNDBG_VENV_PATH}"
-
 ${PYTHON} -m venv -- ${PWNDBG_VENV_PATH}
+
+# Activate venv
 source ${PWNDBG_VENV_PATH}/bin/activate
 
-# Install uv
+# Install uv inside the venv
 pip install uv
 
 # Install dependencies
-uv sync --extra gdb
+echo "Installing dependancies.."
+uv sync --extra gdb --extra lldb --quiet
 
 if [ -z "$UPDATE_MODE" ]; then
     if grep -qs '^[^#]*source.*pwndbg/gdbinit.py' ~/.gdbinit; then
@@ -229,5 +231,6 @@ if [ -z "$UPDATE_MODE" ]; then
         echo "source $PWD/gdbinit.py" >> ~/.gdbinit
         echo "[*] Added 'source $PWD/gdbinit.py' to ~/.gdbinit so that Pwndbg will be loaded on every launch of GDB."
     fi
-    echo "Please set the PWNDBG_NO_AUTOUPDATE environment variable to any value to disable the automatic updating of dependencies when Pwndbg is loaded."
+    echo "Please set the PWNDBG_NO_AUTOUPDATE environment variable to any value"
+    echo "to disable the automatic updating of dependencies when Pwndbg is loaded."
 fi

--- a/tests.sh
+++ b/tests.sh
@@ -8,6 +8,9 @@ glibc_version=$(ldd --version | sed -n '1s/([^)]*)//g; s/.* \([0-9]\+\.[0-9]\+\)
 echo "glibc version: $glibc_version"
 
 # Run integration tests
-(cd tests && $UV_RUN_TEST python3 tests.py $@)
+cd "${PWNDBG_ABS_PATH}/tests"
+
+$UV_RUN_TEST python3 tests.py $@
+
 exit_code=$?
 exit $exit_code

--- a/tests.sh
+++ b/tests.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+source "$(dirname "$0")/scripts/common.sh"
+
 # Use ldd to fetch the glibc version.
 # Can help with diagnosing CI issues.
 glibc_version=$(ldd --version | sed -n '1s/([^)]*)//g; s/.* \([0-9]\+\.[0-9]\+\)$/\1/p')
 echo "glibc version: $glibc_version"
 
 # Run integration tests
-(cd tests && python3 tests.py $@)
+(cd tests && $UV_RUN_TEST python3 tests.py $@)
 exit_code=$?
 exit $exit_code

--- a/tests/qemu-tests/download-kernel-images.sh
+++ b/tests/qemu-tests/download-kernel-images.sh
@@ -11,8 +11,8 @@ mkdir -p "${OUT_DIR}"
 
 download() {
     local file="$1"
-    hash_old=$(grep "${file}" "${OUT_DIR}/hashsums.txt.old" || true)
-    hash_new=$(grep "${file}" "${OUT_DIR}/hashsums.txt")
+    hash_old=$(grep "${file}" "${OUT_DIR}/hashsums.txt.old" 2> /dev/null || true)
+    hash_new=$(grep "${file}" "${OUT_DIR}/hashsums.txt" 2> /dev/null)
     # only download file if it doesn't exist or its hashsum has changed
     if [ ! -f "${OUT_DIR}/${file}" ] || [ "${hash_new}" != "${hash_old}" ]; then
         wget --no-verbose --show-progress --progress=bar:force:noscroll "${URL}/${file}" -O "${OUT_DIR}/${file}"

--- a/tests/qemu-tests/download-kernel-images.sh
+++ b/tests/qemu-tests/download-kernel-images.sh
@@ -2,8 +2,9 @@
 
 set -o errexit
 
-SCRIPT_ABS_DIR="$(dirname "$(realpath "$0")")"
-OUT_DIR="${SCRIPT_ABS_DIR}/images"
+source "$(dirname "$0")/../../scripts/common.sh"
+
+OUT_DIR=$TESTING_KERNEL_IMAGES_DIR
 URL=${URL:-"https://github.com/pwndbg/linux-exploit-dev-env/releases/latest/download"}
 
 mkdir -p "${OUT_DIR}"

--- a/tests/qemu-tests/download_images.sh
+++ b/tests/qemu-tests/download_images.sh
@@ -2,8 +2,8 @@
 
 set -o errexit
 
-CWD=$(dirname -- "$0")
-OUT_DIR="${CWD}/images"
+SCRIPT_ABS_DIR="$(dirname "$(realpath "$0")")"
+OUT_DIR="${SCRIPT_ABS_DIR}/images"
 URL=${URL:-"https://github.com/pwndbg/linux-exploit-dev-env/releases/latest/download"}
 
 mkdir -p "${OUT_DIR}"

--- a/tests/qemu-tests/run-qemu-system.sh
+++ b/tests/qemu-tests/run-qemu-system.sh
@@ -6,10 +6,7 @@ ARCH=""
 KERNEL_TYPE=""
 CMDLINE=""
 
-SCRIPT_ABS_DIR="$(dirname "$(realpath "$0")")"
-IMAGE_DIR="${SCRIPT_ABS_DIR}/images"
-
-KERNEL_LIST=($(basename -a "${IMAGE_DIR}"/vmlinux* | sed "s/vmlinux-//"))
+KERNEL_LIST=($(basename -a "${TESTING_KERNEL_IMAGES_DIR}"/vmlinux* | sed "s/vmlinux-//"))
 GDB_PORT=1234
 help_and_exit() {
     echo "Usage: $0 [options] [-- other qemu options]"
@@ -70,8 +67,8 @@ elif [ "$ARCH" == "x86_64" ]; then
     QEMU_ARGS=()
 fi
 
-KERNEL=$(echo ${IMAGE_DIR}/*Image-${KERNEL_NAME})
-ROOTFS=$(echo ${IMAGE_DIR}/*-${ARCH}.img)
+KERNEL=$(echo ${TESTING_KERNEL_IMAGES_DIR}/*Image-${KERNEL_NAME})
+ROOTFS=$(echo ${TESTING_KERNEL_IMAGES_DIR}/*-${ARCH}.img)
 
 QEMU_ARGS+=(
     -kernel $KERNEL

--- a/tests/qemu-tests/run_qemu_system.sh
+++ b/tests/qemu-tests/run_qemu_system.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+source "$(dirname "$0")/../../scripts/common.sh"
+
 ARCH=""
 KERNEL_TYPE=""
 CMDLINE=""
 
-CWD=$(dirname -- "$0")
-IMAGE_DIR="${CWD}/images"
+SCRIPT_ABS_DIR="$(dirname "$(realpath "$0")")"
+IMAGE_DIR="${SCRIPT_ABS_DIR}/images"
 
 KERNEL_LIST=($(basename -a "${IMAGE_DIR}"/vmlinux* | sed "s/vmlinux-//"))
 GDB_PORT=1234
@@ -80,4 +82,4 @@ QEMU_ARGS+=(
 )
 
 echo "Waiting for GDB to attach (use 'ctrl-a x' to quit)"
-$QEMU_BIN ${QEMU_ARGS[@]} -append "${CMDLINE}"
+$UV_RUN $QEMU_BIN ${QEMU_ARGS[@]} -append "${CMDLINE}"

--- a/tests/qemu-tests/system-tests.sh
+++ b/tests/qemu-tests/system-tests.sh
@@ -5,21 +5,19 @@ set -o pipefail
 
 source "$(dirname "$0")/../../scripts/common.sh"
 
-ROOT_DIR="$(readlink -f ../../)"
+ROOT_DIR=$PWNDBG_ABS_PATH
 GDB_INIT_PATH="$ROOT_DIR/gdbinit.py"
 COVERAGERC_PATH="$ROOT_DIR/pyproject.toml"
 
-CWD=$(dirname -- "$0")
-IMAGE_DIR="${CWD}/images"
-VMLINUX_LIST=($(basename -a "${IMAGE_DIR}"/vmlinux*))
+VMLINUX_LIST=($(basename -a "${TESTING_KERNEL_IMAGES_DIR}"/vmlinux*))
 
-# Ensure we have images directory and directories inside
-if [ ! -d "$IMAGE_DIR" ]; then
-    echo "ERROR: The '$IMAGE_DIR' directory does not exist. Please run ./download_images.sh first"
+# Ensure we have kimages directory and directories inside
+if [ ! -d "$TESTING_KERNEL_IMAGES_DIR" ]; then
+    echo "ERROR: The '$TESTING_KERNEL_IMAGES_DIR' directory does not exist. Please run ./download-kernel-images.sh first"
     exit 1
 fi
 if [ "${VMLINUX_LIST}" = "vmlinux*" ]; then
-    echo "ERROR: The '$IMAGE_DIR' directory does not contain any kernel images. Please run ./download_images.sh first"
+    echo "ERROR: The '$TESTING_KERNEL_IMAGES_DIR' directory does not contain any kernel images. Please run ./download-kernel-images.sh first"
     exit 1
 fi
 
@@ -36,7 +34,7 @@ EOF
 fi
 
 help_and_exit() {
-    echo "Usage: ./tests.sh [-p|--pdb] [-c|--cov] [--nix] [--gdb-port=<port>] [-Q|--preserve-qemu-image] [<test-name-filter>]"
+    echo "Usage: ./system-tests.sh [-p|--pdb] [-c|--cov] [--nix] [--gdb-port=<port>] [-Q|--preserve-qemu-image] [<test-name-filter>]"
     echo "  -p,  --pdb                  enable pdb (Python debugger) post mortem debugger on failed tests"
     echo "  -c,  --cov                  enable codecov"
     echo "  -v,  --verbose              display all test output instead of just failing test output"
@@ -170,7 +168,7 @@ init_gdb() {
     local kernel_version="$2"
     local arch="$3"
 
-    gdb_connect_qemu=(-ex "file ${IMAGE_DIR}/vmlinux-${kernel_type}-${kernel_version}-${arch}" -ex "target remote :${GDB_PORT}")
+    gdb_connect_qemu=(-ex "file ${TESTING_KERNEL_IMAGES_DIR}/vmlinux-${kernel_type}-${kernel_version}-${arch}" -ex "target remote :${GDB_PORT}")
     # using 'rest_init' instead of 'start_kernel' to make sure that kernel
     # initialization has progressed sufficiently for testing purposes
     gdb_args=("${gdb_connect_qemu[@]}" -ex 'break *rest_init' -ex 'continue')
@@ -183,7 +181,7 @@ run_test() {
     local kernel_version="$3"
     local arch="$4"
 
-    gdb_connect_qemu=(-ex "file ${IMAGE_DIR}/vmlinux-${kernel_type}-${kernel_version}-${arch}" -ex "target remote :${GDB_PORT}")
+    gdb_connect_qemu=(-ex "file ${TESTING_KERNEL_IMAGES_DIR}/vmlinux-${kernel_type}-${kernel_version}-${arch}" -ex "target remote :${GDB_PORT}")
     gdb_args=("${gdb_connect_qemu[@]}" --command ../pytests_launcher.py)
     if [ ${RUN_CODECOV} -ne 0 ]; then
         gdb_args=(-ex 'py import coverage;coverage.process_startup()' "${gdb_args[@]}")
@@ -247,7 +245,7 @@ test_system() {
 
     # NOTE: If you run simultaneous tests or left an image lying around via -Q, this
     # will hang due to failure to obtain lock. But will see the error message...
-    "${CWD}/run_qemu_system.sh" --kernel="${kernel_type}-${kernel_version}-${arch}" --gdb-port="${GDB_PORT}" -- "${qemu_args[@]}" > /dev/null &
+    "./run-qemu-system.sh" --kernel="${kernel_type}-${kernel_version}-${arch}" --gdb-port="${GDB_PORT}" -- "${qemu_args[@]}" > /dev/null &
     QEMU_PID=$!
     init_gdb "${kernel_type}" "${kernel_version}" "${arch}"
     start=$(date +%s)

--- a/tests/qemu-tests/system-tests.sh
+++ b/tests/qemu-tests/system-tests.sh
@@ -107,16 +107,16 @@ done
 
 # Test if the port is already listening, possibly by other qemu instance. This
 # can cause unexpected test failures.
-NETSTAT=$(which netstat)
+NETSTAT=$(which netstat 2> /dev/null)
 if [[ -z "${NETSTAT}" ]]; then
-    NETSTAT=$(which ss)
+    NETSTAT=$(which ss 2> /dev/null)
 fi
 if [[ -z "${NETSTAT}" ]]; then
-    echo "WARNING: netstat/ss not found. Cannot check if port ${GDB_PORT} is already bound." >&2
+    echo "ERROR: netstat/ss not found. Cannot check if port ${GDB_PORT} is already bound." >&2
     exit 1
 else
     if [[ $(${NETSTAT} -tuln 2> /dev/null | grep ":${GDB_PORT}" | grep -c LISTEN) -ne 0 ]]; then
-        echo "WARNING: Port ${GDB_PORT} appears already bound. Please specify a different port with --gdb-port=<port>" >&2
+        echo "ERROR: Port ${GDB_PORT} appears already bound. Please specify a different port with --gdb-port=<port>" >&2
         exit 1
     fi
 fi

--- a/tests/qemu-tests/tests.sh
+++ b/tests/qemu-tests/tests.sh
@@ -3,6 +3,8 @@
 #set -o errexit
 set -o pipefail
 
+source "$(dirname "$0")/../../scripts/common.sh"
+
 ROOT_DIR="$(readlink -f ../../)"
 GDB_INIT_PATH="$ROOT_DIR/gdbinit.py"
 COVERAGERC_PATH="$ROOT_DIR/pyproject.toml"
@@ -143,7 +145,8 @@ run_gdb() {
         fi
     fi
 
-    $GDB --silent --nx --nh "${gdb_load_pwndbg[@]}" -ex "set exception-verbose on" "$@" -ex "quit" 2> /dev/null
+    $UV_RUN $GDB --silent --nx --nh "${gdb_load_pwndbg[@]}" \
+        -ex "set exception-verbose on" "$@" -ex "quit" 2> /dev/null
     return $?
 }
 

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "$(dirname "$0")/scripts/common.sh"
+
 COV=0
 # Run unit tests
 for arg in "$@"; do
@@ -10,9 +12,9 @@ for arg in "$@"; do
 done
 
 if [ $COV -eq 1 ]; then
-    coverage run -m pytest tests/unit-tests
+    $UV_RUN_TEST coverage run -m pytest tests/unit-tests
 else
-    pytest tests/unit-tests
+    $UV_RUN_TEST pytest tests/unit-tests
 fi
 
 exit_code=$((exit_code + $?))

--- a/uv.lock
+++ b/uv.lock
@@ -1254,6 +1254,7 @@ dependencies = [
     { name = "tabulate" },
     { name = "typing-extensions" },
     { name = "unicorn" },
+    { name = "uv" },
 ]
 
 [package.optional-dependencies]
@@ -1318,6 +1319,7 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
     { name = "typing-extensions", specifier = ">=4.12.0,<5" },
     { name = "unicorn", specifier = ">=2.1.3,<3" },
+    { name = "uv", specifier = ">=0.7.6" },
 ]
 provides-extras = ["lldb", "gdb"]
 
@@ -2122,6 +2124,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.7.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/47/a34396a3ec86d39f1e6ad5cff90521d8347b94be22d83f2bc2a60e4c76dd/uv-0.7.7.tar.gz", hash = "sha256:e93b2a33d103d4c5a3e8119ca8e62412e72f6816fee74bd671c2060447f98d93", size = 3261356, upload-time = "2025-05-22T19:19:51.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b6/0dba66788f154c214d8fcf8f4c9fa6dd6067aab2b3b32667cffbe42fee6e/uv-0.7.7-py3-none-linux_armv6l.whl", hash = "sha256:ce79f1968bb55cb0a1eccd0db2738221d9f1ef1bc49656c28a21790e12e2031e", size = 16713167, upload-time = "2025-05-22T19:19:08.021Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/46fedbd1ecb8833b359304160d1d18f9cd2e77fc3fa7f7a7558b37a08348/uv-0.7.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9f4216f74b38f99a15e7b1c44ba9095b3af2e75ec2513173b8ec24afe64418a7", size = 16823385, upload-time = "2025-05-22T19:19:12.096Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f4/a0effbde89c9ed71180dc9f1eabb8c2c492dafe72c20f70abc2f53426287/uv-0.7.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:31112b05e913eea2a3053b83ae9a77155aac46d91d3e06a069da13c0120ed38a", size = 15648410, upload-time = "2025-05-22T19:19:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f5/50582ca9dd092eb04951bbfc4a31fea457562280e8c7370615453e9a1838/uv-0.7.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:3d313f629014ed0532c144dd0d15e77eca20bd3816821059b49b3f74dc9cb68a", size = 16078402, upload-time = "2025-05-22T19:19:17.198Z" },
+    { url = "https://files.pythonhosted.org/packages/19/71/49c817f91d69235a8899e1e4a4603ad4a2c638113d05fcac3acc95ba625d/uv-0.7.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53f3e970e94d3b21cae128e2b7200444f1e3f020767608d71c2a6edb3e4ba8f2", size = 16411326, upload-time = "2025-05-22T19:19:19.699Z" },
+    { url = "https://files.pythonhosted.org/packages/08/de/f4b413c13cd8301822718a88a1ef861b65abe7454303f0a13c843db27ee7/uv-0.7.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:574b1e1c093dffc449542c841ed7fe9441d4154c922ae86dfc025cec0d2b6f24", size = 17188171, upload-time = "2025-05-22T19:19:22.101Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/01/52a8b230c0e09940c005b4b9cc82fb8e2aea316ab66ce5a8ea8efbce67be/uv-0.7.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1da8bea1251bcee4f93754873ba57cf4e36a21f6a92586adb0e573a14ecd2a0d", size = 18105617, upload-time = "2025-05-22T19:19:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a1/a4b3bd55b1ad5e8fe67546c41daee1c36610c8de6a0b72b4364b97c368fa/uv-0.7.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1102e79165ae9c3aa474a6e72c18634d6dacf012f16b3404fe539fd46628f915", size = 17771349, upload-time = "2025-05-22T19:19:26.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/af/5fe96e15ddc2a8c0f7414e3d1192783e39c70e847cf5b81b01a855dc8d8f/uv-0.7.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41a2b8484376f02578995a7440b3897de07043e56ad2b730dae021cd40b8808d", size = 22156530, upload-time = "2025-05-22T19:19:29.318Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/86/c1797bf935c758428f362bf14f7a370cb3602f8db620bba05e25fa395c77/uv-0.7.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa56eeee7624ed13aad91395df1abe556f165ebc3a467b2afb5a5757ee7c094f", size = 17482804, upload-time = "2025-05-22T19:19:31.652Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/aa/c505f719a7b18c6c624c8d20440330dc2dca8862b997f4025a429817464d/uv-0.7.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:c8d486e3e82b2b52ab44d493953cc83a54d412b5c1ce64d078f2bea7c7a00f2c", size = 16328661, upload-time = "2025-05-22T19:19:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ce07a0f4b06611ba4ad428d380127d86d20c20ed0ac31b90dfbe83045cea/uv-0.7.7-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:40441f5da2355fe487fdd763fce6cdf82824189d3b8386fc91ce6cbf956c6cda", size = 16407141, upload-time = "2025-05-22T19:19:37.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fc/6a49b2d230b516058198e1432254eab4033a8a9ef17f91788c17c45a9f56/uv-0.7.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:752af3316028c30cb6f06c53cabcbf2851a9a2882729db73e05b61cb153d859c", size = 16744495, upload-time = "2025-05-22T19:19:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/97/63/41db7b08779ab36d75db5466c7b951e6ee45c57cb7188779b448aeb6d4b9/uv-0.7.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:fa5180f3c0ad7f3b02b4b23b79594bf50dbf7fad7387adb685065c2cb79fb04f", size = 17579811, upload-time = "2025-05-22T19:19:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/0c/14ae71568542be70ac88f6d296a9136855a8c64cf6c908a222ce1867fcaf/uv-0.7.7-py3-none-win32.whl", hash = "sha256:eec86f6edf3f79e446d13ae688d3d62e6096c27bef956ceeb68942db8fbccb12", size = 16997789, upload-time = "2025-05-22T19:19:43.984Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ef/f97703fc5c60089fa253286516b255f6aaefad8c02533418d3489ba8edad/uv-0.7.7-py3-none-win_amd64.whl", hash = "sha256:674b85efec84ef468dd834760db34301a823f87e115e26c77634390bf1ab98c7", size = 18488277, upload-time = "2025-05-22T19:19:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f8/4202493e0cddca68fe8711513958599cee6b7c7660dd13328870c2204aef/uv-0.7.7-py3-none-win_arm64.whl", hash = "sha256:495b0227f0051234db2f8582e3368ac2e43f6d7437dc7c9df03b2df55dd4c5cd", size = 17192181, upload-time = "2025-05-22T19:19:49.59Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
todo: rebase after https://github.com/pwndbg/pwndbg/pull/2986 is merged.

I was very confused when I was first trying to understand the testing infra so I renamed some stuff to hopefully make it more clear to people looking at it for the first time. The most relevant rename is `./qemu-tests.sh` -> `./crossarch-tests.sh` (because the script, despite its name, doesn't run all qemu tests). Also, added a script that runs the kernel tests.

We are missing the iproute2 dependancy for the ubuntu docker to be able to run the kernel tests, so I added it to `setup-dev.sh`. The other distributions are still missing packages, for instance pacman is missing the qemu stuff. 

Side-note:
Without the netstat change, the arch container will report that netstat is installed even when it isn't because `which` outputs a message to stderr.